### PR TITLE
Ensure source term shared across threads

### DIFF
--- a/wave_propagation/Types.h
+++ b/wave_propagation/Types.h
@@ -1,4 +1,4 @@
-#pragma one  // Esto es para que se compile una sola vez y no ocurran errores
+#pragma once  // Esto es para que se compile una sola vez y no ocurran errores
 
 enum class ScheduleType {      //Enumeracion con Scope para evitar colisiones de nombre
     Static,         // opciones del planificador

--- a/wave_propagation/WavePropagator.cpp
+++ b/wave_propagation/WavePropagator.cpp
@@ -18,11 +18,11 @@ void WavePropagator::run_fused(int steps, ScheduleType st, int chunk, const std:
     double local_t = tcur_;
     double E_global = 0.0;
 
+    double s_val = 0.0;
     #pragma omp parallel default(none) \
-        shared(nodes, N, D, g, st, chunk, steps, dt, local_t, S0_, omega_, E_global, trace)
+        shared(nodes, N, D, g, st, chunk, steps, dt, local_t, S0_, omega_, E_global, trace, s_val)
     {
         for (int it=0; it<steps; ++it){
-            double s_val = 0.0;
             #pragma omp single
             { s_val = (omega_!=0.0) ? (S0_*std::sin(omega_*local_t)) : S0_; E_global = 0.0; }
 


### PR DESCRIPTION
## Summary
- share the source value across OpenMP threads in `WavePropagator::run_fused` so it is computed once per iteration
- fix the include guard pragma in `Types.h` so the project rebuilds cleanly

## Testing
- `make`
- `./tmp_verify`


------
https://chatgpt.com/codex/tasks/task_e_68dabed6ce98832c8d1b6e888822d52f