### PR TITLE
Add synchronization barrier before energy trace logging

### DIFF
--- a/wave_propagation/WavePropagator.cpp
+++ b/wave_propagation/WavePropagator.cpp
@@ -62,10 +62,10 @@ void WavePropagator::run_fused(int steps, ScheduleType st, int chunk, const std:
             #pragma omp for nowait
             for (int i=0;i<N;++i) nodes[i].commit();
 
+            #pragma omp barrier
+
             #pragma omp single
             { trace.emplace_back(it+1, E_global); local_t += dt; }
-
-            #pragma omp barrier
         }
     }
 


### PR DESCRIPTION
## Summary
- insert an explicit OpenMP barrier between the commit loop and the single section that records the energy trace in `WavePropagator::run_fused`
- remove the redundant barrier at the end of the iteration since synchronization is now provided by the new barrier and the implicit barrier on the `single`

## Testing
- make clean && make
- OMP_NUM_THREADS=4 ./wave_propagation --steps 5 --schedule static --chunk 10 --network 1d --N 100 --D 0.1 --gamma 0.01 --dt 0.01 --S0 0.1 --omega 0.5

------
https://chatgpt.com/codex/tasks/task_e_68dac10be050832c97c241150584f0f2