### PR TITLE
Add representative benchmark scenarios to run_matrix runner

### DIFF
--- a/wave_propagation/scripts/run_matrix.py
+++ b/wave_propagation/scripts/run_matrix.py
@@ -1,132 +1,254 @@
 
-import subprocess, sys, time, csv, os
+import csv
+import os
+import subprocess
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Dict, List, Sequence
 
-def exe_path():
-    # Try to autodetect exe name cross-platform
-    cand = ["wave_propagation", "wave_propagation.exe", "./wave_propagation", "./wave_propagation.exe"]
-    for c in cand:
-        p = Path(c)
-        if p.exists() and p.is_file():
-            return str(p)
-    # Fallback: assume in current dir
+
+def exe_path() -> str:
+    """Try to autodetect the wave_propagation executable."""
+
+    candidates = [
+        "wave_propagation",
+        "wave_propagation.exe",
+        "./wave_propagation",
+        "./wave_propagation.exe",
+    ]
+    for candidate in candidates:
+        candidate_path = Path(candidate)
+        if candidate_path.exists() and candidate_path.is_file():
+            return str(candidate_path)
+
+    # Fallback: assume the executable lives next to the script
     return "./wave_propagation"
 
-def parse_energy(path):
-    # returns (E0, Eend, lines_count)
+
+def parse_energy(path: Path) -> tuple:
+    """Parse a generated energy trace and return (E0, Eend, lines_count)."""
+
     E0, Eend = None, None
     lines = 0
-    if not Path(path).exists():
+    if not path.exists():
         return (None, None, 0)
-    with open(path, "r", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            s = line.strip()
-            if not s or s.startswith("#"): continue
-            parts = s.split()
-            if len(parts)>=2:
+
+    with path.open("r", encoding="utf-8", errors="ignore") as handler:
+        for line in handler:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            parts = stripped.split()
+            if len(parts) >= 2:
                 try:
-                    step = int(float(parts[0]))
-                    e = float(parts[1])
-                    if E0 is None: E0 = e
-                    Eend = e
-                    lines += 1
-                except:
-                    pass
+                    _ = int(float(parts[0]))
+                    energy_value = float(parts[1])
+                except ValueError:
+                    continue
+
+                if E0 is None:
+                    E0 = energy_value
+                Eend = energy_value
+                lines += 1
+
     return (E0, Eend, lines)
 
-def main():
+
+@dataclass(frozen=True)
+class Scenario:
+    label: str
+    network: str
+    dims: Dict[str, int]
+    schedule: str
+    chunks: Sequence[object]
+    threads: Sequence[int]
+    steps: int = 1000
+    extra_args: Dict[str, float] = field(default_factory=dict)
+
+
+def build_command(exe: str, scenario: Scenario, chunk, threads: int) -> List[str]:
+    cmd = [
+        exe,
+        "--network",
+        scenario.network,
+        "--steps",
+        str(scenario.steps),
+        "--schedule",
+        scenario.schedule,
+        "--chunk",
+        str(chunk),
+        "--threads",
+        str(threads),
+    ]
+
+    if scenario.network == "1d":
+        cmd.extend(["--N", str(scenario.dims["N"])])
+    else:
+        cmd.extend([
+            "--Lx",
+            str(scenario.dims["Lx"]),
+            "--Ly",
+            str(scenario.dims["Ly"]),
+        ])
+
+    for key, value in scenario.extra_args.items():
+        cmd.extend([f"--{key}", str(value)])
+
+    return cmd
+
+
+def run_scenario(exe: str, scenario: Scenario, results_dir: Path) -> List[Dict[str, object]]:
+    rows: List[Dict[str, object]] = []
+
+    for chunk in scenario.chunks:
+        for threads in scenario.threads:
+            cmd = build_command(exe, scenario, chunk, threads)
+
+            t0 = time.perf_counter()
+            completed = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            elapsed = time.perf_counter() - t0
+
+            src_energy = results_dir / "energy_trace.dat"
+            E0, Eend, lines = parse_energy(src_energy)
+            energy_out = (
+                results_dir
+                / f"energy_{scenario.label}_chunk{chunk}_t{threads}.dat"
+            )
+            if src_energy.exists():
+                try:
+                    src_energy.rename(energy_out)
+                except OSError:
+                    import shutil
+
+                    shutil.copyfile(src_energy, energy_out)
+                    os.remove(src_energy)
+
+            row = {
+                "label": scenario.label,
+                "network": scenario.network,
+                **scenario.dims,
+                "steps": scenario.steps,
+                "schedule": scenario.schedule,
+                "chunk": str(chunk),
+                "threads": threads,
+                "time_sec": round(elapsed, 6),
+                "E0": E0 if E0 is not None else "",
+                "Eend": Eend if Eend is not None else "",
+                "energy_lines": lines,
+                "stdout_last": (
+                    completed.stdout.strip().splitlines()[-1]
+                    if completed.stdout
+                    else ""
+                ),
+                "stderr_last": (
+                    completed.stderr.strip().splitlines()[-1]
+                    if completed.stderr
+                    else ""
+                ),
+            }
+            rows.append(row)
+            print(f"OK: {row}")
+
+    return rows
+
+
+def main() -> None:
     exe = exe_path()
     results_dir = Path("results")
     results_dir.mkdir(exist_ok=True)
-    csv_path = results_dir/"matrix_results.csv"
+    csv_path = results_dir / "matrix_results.csv"
 
-    # Test matrix (toca si quieres menos/más casos)
-    networks = [
-        ("1d", {"N": 20000}),
-        ("2d", {"Lx": 256, "Ly": 256}),
+    scenarios: List[Scenario] = [
+        Scenario(
+            label="2d_dynamic_best",
+            network="2d",
+            dims={"Lx": 256, "Ly": 256},
+            schedule="dynamic",
+            chunks=[512],
+            threads=[1, 2, 4, 8],
+        ),
+        Scenario(
+            label="2d_guided_alternative",
+            network="2d",
+            dims={"Lx": 256, "Ly": 256},
+            schedule="guided",
+            chunks=[256],
+            threads=[1, 2, 4, 8],
+        ),
+        Scenario(
+            label="2d_static_bad",
+            network="2d",
+            dims={"Lx": 256, "Ly": 256},
+            schedule="static",
+            chunks=[512],
+            threads=[1, 8],
+        ),
+        Scenario(
+            label="2d_dynamic_chunk_sweep",
+            network="2d",
+            dims={"Lx": 256, "Ly": 256},
+            schedule="dynamic",
+            chunks=[128, 256, 512, "auto"],
+            threads=[8],
+        ),
+        Scenario(
+            label="1d_small_bad",
+            network="1d",
+            dims={"N": 20000},
+            schedule="static",
+            chunks=[512],
+            threads=[1, 2, 4],
+        ),
+        Scenario(
+            label="1d_large_better",
+            network="1d",
+            dims={"N": 200000},
+            schedule="dynamic",
+            chunks=[256],
+            threads=[1, 2, 4],
+        ),
     ]
-    steps = 400
-    dt = 0.01
-    D = 0.1
-    gamma = 0.01
-    sources = [(0.0, 0.0), (0.1, 0.5)]  # (S0, omega)
 
-    schedules = ["static", "dynamic", "guided"]
-    chunks = ["auto", 64, 128, 256, 512]
-    threads_list = [1, 2, 4, 8]
+    rows: List[Dict[str, object]] = []
+    for scenario in scenarios:
+        rows.extend(run_scenario(exe, scenario, results_dir))
 
-    rows = []
-    for net_name, dims in networks:
-        for (S0, omega) in sources:
-            for sched in schedules:
-                for chunk in chunks:
-                    for thr in threads_list:
-                        # Build command
-                        cmd = [exe, "--network", net_name,
-                               "--steps", str(steps),
-                               "--dt", str(dt),
-                               "--D", str(D),
-                               "--gamma", str(gamma),
-                               "--S0", str(S0),
-                               "--omega", str(omega),
-                               "--schedule", sched,
-                               "--chunk", str(chunk) if chunk!="auto" else "auto",
-                               "--threads", str(thr)]
-                        if net_name == "1d":
-                            cmd += ["--N", str(dims["N"])]
-                        else:
-                            cmd += ["--Lx", str(dims["Lx"]), "--Ly", str(dims["Ly"])]
-                        # Run
-                        t0 = time.perf_counter()
-                        cp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-                        t1 = time.perf_counter()
-                        elapsed = t1 - t0
+    cols = [
+        "label",
+        "network",
+        "N",
+        "Lx",
+        "Ly",
+        "steps",
+        "schedule",
+        "chunk",
+        "threads",
+        "time_sec",
+        "E0",
+        "Eend",
+        "energy_lines",
+        "stdout_last",
+        "stderr_last",
+    ]
 
-                        # Move/rename energy trace to keep it
-                        src_energy = results_dir/"energy_trace.dat"
-                        E0, Eend, lines = parse_energy(src_energy) if src_energy.exists() else (None, None, 0)
-                        out_energy = results_dir/f"energy_{net_name}_S{S0}_w{omega}_{sched}_chunk{chunk}_t{thr}.dat"
-                        if src_energy.exists():
-                            try:
-                                src_energy.rename(out_energy)
-                            except Exception:
-                                # If rename fails (Windows locks), copy then remove
-                                import shutil
-                                shutil.copyfile(src_energy, out_energy)
-                                os.remove(src_energy)
-
-                        row = {
-                            "network": net_name,
-                            **{k:v for k,v in dims.items()},
-                            "steps": steps,
-                            "S0": S0, "omega": omega,
-                            "schedule": sched,
-                            "chunk": str(chunk),
-                            "threads": thr,
-                            "time_sec": round(elapsed, 6),
-                            "E0": E0 if E0 is not None else "",
-                            "Eend": Eend if Eend is not None else "",
-                            "energy_lines": lines,
-                            "stdout_last": (cp.stdout.strip().splitlines()[-1] if cp.stdout else ""),
-                            "stderr_last": (cp.stderr.strip().splitlines()[-1] if cp.stderr else "")
-                        }
-                        rows.append(row)
-                        print(f"OK: {row}")
-
-    # Write CSV
-    cols = ["network","N","Lx","Ly","steps","S0","omega","schedule","chunk","threads","time_sec","E0","Eend","energy_lines","stdout_last","stderr_last"]
-    with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        w = csv.DictWriter(f, fieldnames=cols)
-        w.writeheader()
-        for r in rows:
-            # fill missing keys (depending on 1d/2d)
-            if "N" not in r: r["N"]=""
-            if "Lx" not in r: r["Lx"]=""
-            if "Ly" not in r: r["Ly"]=""
-            w.writerow(r)
+    with csv_path.open("w", newline="", encoding="utf-8") as handler:
+        writer = csv.DictWriter(handler, fieldnames=cols)
+        writer.writeheader()
+        for row in rows:
+            row.setdefault("N", "")
+            row.setdefault("Lx", "")
+            row.setdefault("Ly", "")
+            writer.writerow(row)
 
     print(f"\nResultados guardados en {csv_path}")
     print("Energías únicas en results/energy_*.dat")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the generic parameter sweep in `run_matrix.py` with the representative scenarios described in the lab handout
- capture timings, energy traces, and metadata for each curated case while keeping the CSV/energy artifacts up to date

## Testing
- python3 -m compileall wave_propagation/scripts/run_matrix.py

------
https://chatgpt.com/codex/tasks/task_e_68daf5133630832cb1aa5a2e9ecfe129