### PR TITLE
Add noise modes, energy accumulation options, and analysis tooling

### DIFF
--- a/wave_propagation/Benchmark.cpp
+++ b/wave_propagation/Benchmark.cpp
@@ -40,9 +40,26 @@ void Benchmark::run_scaling(Network& net, int steps, ScheduleType st, int chunk,
         for (int r=0;r<reps;++r){
             reset_initial(net);
             omp_set_num_threads(p);
-            WavePropagator wp(&net, /*dt*/0.01, /*S0*/0.0, /*omega*/0.0);
+            RunParams bench_params;
+            bench_params.steps = steps;
+            bench_params.schedule = st;
+            bench_params.chunk = chunk;
+            bench_params.dt = 0.01;
+            bench_params.S0 = 0.0;
+            bench_params.omega = 0.0;
+            bench_params.noise = NoiseMode::Off;
+            bench_params.energyAccum = EnergyAccum::Reduction;
+            bench_params.taskloop = false;
+            bench_params.dump_frames = false;
+            bench_params.energy_out.clear();
+            bench_params.network = net.is2D() ? "2d" : "1d";
+            bench_params.N = net.size();
+            bench_params.Lx = net.Lx();
+            bench_params.Ly = net.Ly();
+            bench_params.threads = p;
+            WavePropagator wp(net, bench_params);
             double t0 = omp_get_wtime();
-            wp.run_fused(steps, st, chunk, /*energy_out*/"");
+            wp.run(bench_params.energy_out);
             double t1 = omp_get_wtime();
             times.push_back(t1-t0);
         }
@@ -125,9 +142,26 @@ void Benchmark::run_time_vs_chunk_dynamic(Network& net, int steps, int threads, 
         std::vector<double> times;
         for (int r=0;r<reps;++r){
             reset_initial(net);
-            WavePropagator wp(&net, 0.01, 0.0, 0.0);
+            RunParams bench_params;
+            bench_params.steps = steps;
+            bench_params.schedule = ScheduleType::Dynamic;
+            bench_params.chunk = c;
+            bench_params.dt = 0.01;
+            bench_params.S0 = 0.0;
+            bench_params.omega = 0.0;
+            bench_params.noise = NoiseMode::Off;
+            bench_params.energyAccum = EnergyAccum::Reduction;
+            bench_params.taskloop = false;
+            bench_params.dump_frames = false;
+            bench_params.energy_out.clear();
+            bench_params.network = net.is2D() ? "2d" : "1d";
+            bench_params.N = net.size();
+            bench_params.Lx = net.Lx();
+            bench_params.Ly = net.Ly();
+            bench_params.threads = threads;
+            WavePropagator wp(net, bench_params);
             double t0 = omp_get_wtime();
-            wp.run_fused(steps, ScheduleType::Dynamic, c, "");
+            wp.run(bench_params.energy_out);
             double t1 = omp_get_wtime();
             times.push_back(t1-t0);
         }

--- a/wave_propagation/Makefile
+++ b/wave_propagation/Makefile
@@ -13,5 +13,18 @@ clean:
 	rm -f $(TARGET) *.o
 	rm -rf results
 
+.PHONY: clean benchmark analysis
+
 benchmark: $(TARGET)
+	@mkdir -p results
 	./$(TARGET) --benchmark
+
+analysis: $(TARGET)
+	@mkdir -p results results/frames
+	@echo "[analysis] corriendo escalamiento..."
+	@./$(TARGET) --network 2d --Lx 256 --Ly 256 --steps 800 --schedule dynamic --chunk auto \
+	        --threads 8 --energy-accum reduction --noise pernode --S0 0.05 \
+	        --omega-mu 8.0 --omega-sigma 1.5 --collapse2 --dump-frames --frame-every 20
+	@python3 scripts/plot_speedup.py
+	@python3 scripts/plot_chunk.py
+	@python3 scripts/make_video.py results/frames out.gif

--- a/wave_propagation/Types.h
+++ b/wave_propagation/Types.h
@@ -1,7 +1,52 @@
 #pragma once  // Esto es para que se compile una sola vez y no ocurran errores
 
+#include <string>
+
 enum class ScheduleType {      //Enumeracion con Scope para evitar colisiones de nombre
     Static,         // opciones del planificador
     Dynamic,
     Guided
+};
+
+enum class NoiseMode { Off = 0, Global, PerNode, Single };
+enum class EnergyAccum { Reduction = 0, Atomic, Critical };
+
+struct RunParams {
+    // parámetros de topología / simulación
+    std::string network = "2d"; // {1d,2d}
+    int N = 10000;              // tamaño 1D
+    int Lx = 100, Ly = 100;     // tamaño 2D
+    double D = 0.1;             // difusión
+    double gamma = 0.01;        // amortiguamiento
+    double dt = 0.01;           // paso de tiempo
+    int steps = 200;            // pasos a simular
+
+    // fuente base
+    double S0 = 0.0;
+    double omega = 0.0;
+
+    // ruido
+    NoiseMode noise = NoiseMode::Off;
+    double omega_mu = 10.0;
+    double omega_sigma = 1.0;
+    int noise_node = -1;
+
+    // openmp / scheduling
+    ScheduleType schedule = ScheduleType::Dynamic;
+    int chunk = 32;
+    bool chunk_auto = false;
+    int threads = 0; // 0 => usar configuracion por defecto de OMP
+    bool fused = true;
+    bool taskloop = false;
+    int grain = 4096;
+
+    // acumulación de energía
+    EnergyAccum energyAccum = EnergyAccum::Reduction;
+
+    // opciones extra
+    bool collapse2 = false;
+    bool dump_frames = false;
+    int frame_every = 10;
+    bool do_bench = false;
+    std::string energy_out = "results/energy_trace.dat";
 };

--- a/wave_propagation/WavePropagator.cpp
+++ b/wave_propagation/WavePropagator.cpp
@@ -1,82 +1,278 @@
 #include "WavePropagator.h"
-#include <omp.h>
-#include <fstream>
-#include <filesystem>
-#include <vector>
+
 #include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <iomanip>
+#include <omp.h>
 
-void WavePropagator::run_fused(int steps, ScheduleType st, int chunk, const std::string& energy_out){
-    auto& nodes = net_->data();
-    const int N = net_->size();
-    const double D = net_->diffusion();
-    const double g = net_->damping();
+WavePropagator::WavePropagator(Network& net, const RunParams& params)
+    : net_(net), params_(params), rng_(std::random_device{}()), norm_(params_.omega_mu, params_.omega_sigma)
+{
+    if (params_.noise == NoiseMode::PerNode){
+        omega_i_.resize(net_.size());
+        for (double& w : omega_i_) w = norm_(rng_);
+    } else if (params_.noise == NoiseMode::Single){
+        single_idx_ = params_.noise_node;
+        if (single_idx_ < 0 || single_idx_ >= net_.size()){
+            single_idx_ = net_.is2D()
+                ? ((net_.Ly()/2) * net_.Lx() + (net_.Lx()/2))
+                : (net_.Lx()/2);
+        }
+        omega_i_.assign(net_.size(), 0.0);
+        if (single_idx_ >= 0 && single_idx_ < net_.size()){
+            omega_i_[single_idx_] = norm_(rng_);
+        }
+    }
+}
 
-    std::vector<std::pair<int,double>> trace;
-    trace.reserve(steps);
+double WavePropagator::source_val(int idx, double time) const{
+    switch (params_.noise){
+        case NoiseMode::Off:
+            return (params_.omega != 0.0) ? params_.S0 * std::sin(params_.omega * time) : params_.S0;
+        case NoiseMode::Global:
+            return params_.S0 * std::sin(params_.omega * time);
+        case NoiseMode::PerNode:
+            if (idx >= 0 && idx < (int)omega_i_.size())
+                return params_.S0 * std::sin(omega_i_[idx] * time);
+            return 0.0;
+        case NoiseMode::Single:
+            if (idx == single_idx_ && idx >= 0 && idx < (int)omega_i_.size())
+                return params_.S0 * std::sin(omega_i_[idx] * time);
+            return 0.0;
+    }
+    return 0.0;
+}
 
-    const double dt = dt_;
+void WavePropagator::dump_energy(std::ofstream& fe, int step, double E){
+    if (step == 1) fe << "# step\tE\n";
+    fe << step << "\t" << std::setprecision(12) << E << "\n";
+}
+
+void WavePropagator::dump_frame_1d(int step){
+    char name[256];
+    std::snprintf(name, sizeof(name), "results/frames/amp_t%06d.dat", step);
+    std::ofstream f(name);
+    if (!f) return;
+    auto& nodes = net_.data();
+    for (int x=0; x<net_.Lx(); ++x){
+        int idx = x;
+        if (idx >= 0 && idx < (int)nodes.size())
+            f << nodes[idx].get() << "\n";
+    }
+}
+
+void WavePropagator::dump_frame_2d(int step){
+    char name[256];
+    std::snprintf(name, sizeof(name), "results/frames/amp_t%06d.csv", step);
+    std::ofstream f(name);
+    if (!f) return;
+    auto& nodes = net_.data();
+    const int Lx = net_.Lx();
+    const int Ly = net_.Ly();
+    for (int y=0; y<Ly; ++y){
+        for (int x=0; x<Lx; ++x){
+            int idx = y*Lx + x;
+            double val = (idx >= 0 && idx < (int)nodes.size()) ? nodes[idx].get() : 0.0;
+            f << val;
+            if (x+1<Lx) f << ',';
+        }
+        f << '\n';
+    }
+}
+
+void WavePropagator::run(const std::string& energy_out){
+    auto& nodes = net_.data();
+    const int N = net_.size();
+    const double D = net_.diffusion();
+    const double g = net_.damping();
+
+    std::ofstream energy_file;
+    if (!energy_out.empty()){
+        std::filesystem::path p(energy_out);
+        if (p.has_parent_path()) std::filesystem::create_directories(p.parent_path());
+        energy_file.open(energy_out);
+    }
+
+    if (params_.dump_frames){
+        std::filesystem::create_directories("results/frames");
+    }
+
+    const int chunk = params_.chunk > 0 ? params_.chunk : 1;
+    const int grain = params_.grain > 0 ? params_.grain : 1;
+
+    double dt = params_.dt;
     double local_t = tcur_;
+    double time_for_step = 0.0;
     double E_global = 0.0;
 
-    double s_val = 0.0;
-    #pragma omp parallel default(none) \
-        shared(nodes, N, D, g, st, chunk, steps, dt, local_t, S0_, omega_, E_global, trace, s_val)
+    const int Lx = net_.Lx();
+    const int Ly = net_.Ly();
+
+    #pragma omp parallel shared(time_for_step, E_global)
     {
-        for (int it=0; it<steps; ++it){
+        for (int it=0; it<params_.steps; ++it){
             #pragma omp single
-            { s_val = (omega_!=0.0) ? (S0_*std::sin(omega_*local_t)) : S0_; E_global = 0.0; }
+            {
+                time_for_step = local_t;
+                E_global = 0.0;
+            }
 
-            // Update (leer prev, escribir actual)
-            if (st == ScheduleType::Static){
-                #pragma omp for schedule(static,chunk)
-                for (int i=0;i<N;++i){
-                    double ai = nodes[i].getPrev();
-                    const auto& nb = nodes[i].neighbors();
-                    double acc=0.0; for (int j: nb) acc += (nodes[j].getPrev() - ai);
-                    nodes[i].set( ai + dt*(D*acc - g*ai + s_val) );
+            auto update_index = [&](int idx){
+                double ai = nodes[idx].getPrev();
+                const auto& nb = nodes[idx].neighbors();
+                double acc = 0.0;
+                for (int j : nb){
+                    acc += (nodes[j].getPrev() - ai);
                 }
-            } else if (st == ScheduleType::Dynamic){
-                #pragma omp for schedule(dynamic,chunk)
-                for (int i=0;i<N;++i){
-                    double ai = nodes[i].getPrev();
-                    const auto& nb = nodes[i].neighbors();
-                    double acc=0.0; for (int j: nb) acc += (nodes[j].getPrev() - ai);
-                    nodes[i].set( ai + dt*(D*acc - g*ai + s_val) );
+                double s = source_val(idx, time_for_step);
+                nodes[idx].set(ai + dt*(D*acc - g*ai + s));
+            };
+
+            if (params_.taskloop){
+                if (net_.is2D()){
+                    #pragma omp single
+                    {
+                        #pragma omp taskloop grainsize(grain)
+                        for (int y=0; y<Ly; ++y){
+                            for (int x=0; x<Lx; ++x){
+                                int idx = y*Lx + x;
+                                update_index(idx);
+                            }
+                        }
+                        #pragma omp taskwait
+                    }
+                } else {
+                    #pragma omp single
+                    {
+                        #pragma omp taskloop grainsize(grain)
+                        for (int i=0; i<N; ++i){
+                            update_index(i);
+                        }
+                        #pragma omp taskwait
+                    }
                 }
-            } else { // Guided
-                #pragma omp for schedule(guided,chunk)
-                for (int i=0;i<N;++i){
-                    double ai = nodes[i].getPrev();
-                    const auto& nb = nodes[i].neighbors();
-                    double acc=0.0; for (int j: nb) acc += (nodes[j].getPrev() - ai);
-                    nodes[i].set( ai + dt*(D*acc - g*ai + s_val) );
+            } else if (net_.is2D()){
+                if (params_.collapse2){
+                    if (params_.schedule == ScheduleType::Static){
+                        #pragma omp for schedule(static, chunk) collapse(2)
+                        for (int y=0; y<Ly; ++y){
+                            for (int x=0; x<Lx; ++x){
+                                int idx = y*Lx + x;
+                                update_index(idx);
+                            }
+                        }
+                    } else if (params_.schedule == ScheduleType::Dynamic){
+                        #pragma omp for schedule(dynamic, chunk) collapse(2)
+                        for (int y=0; y<Ly; ++y){
+                            for (int x=0; x<Lx; ++x){
+                                int idx = y*Lx + x;
+                                update_index(idx);
+                            }
+                        }
+                    } else {
+                        #pragma omp for schedule(guided, chunk) collapse(2)
+                        for (int y=0; y<Ly; ++y){
+                            for (int x=0; x<Lx; ++x){
+                                int idx = y*Lx + x;
+                                update_index(idx);
+                            }
+                        }
+                    }
+                } else {
+                    if (params_.schedule == ScheduleType::Static){
+                        #pragma omp for schedule(static, chunk)
+                        for (int y=0; y<Ly; ++y){
+                            for (int x=0; x<Lx; ++x){
+                                int idx = y*Lx + x;
+                                update_index(idx);
+                            }
+                        }
+                    } else if (params_.schedule == ScheduleType::Dynamic){
+                        #pragma omp for schedule(dynamic, chunk)
+                        for (int y=0; y<Ly; ++y){
+                            for (int x=0; x<Lx; ++x){
+                                int idx = y*Lx + x;
+                                update_index(idx);
+                            }
+                        }
+                    } else {
+                        #pragma omp for schedule(guided, chunk)
+                        for (int y=0; y<Ly; ++y){
+                            for (int x=0; x<Lx; ++x){
+                                int idx = y*Lx + x;
+                                update_index(idx);
+                            }
+                        }
+                    }
+                }
+            } else {
+                if (params_.schedule == ScheduleType::Static){
+                    #pragma omp for schedule(static, chunk)
+                    for (int i=0; i<N; ++i){
+                        update_index(i);
+                    }
+                } else if (params_.schedule == ScheduleType::Dynamic){
+                    #pragma omp for schedule(dynamic, chunk)
+                    for (int i=0; i<N; ++i){
+                        update_index(i);
+                    }
+                } else {
+                    #pragma omp for schedule(guided, chunk)
+                    for (int i=0; i<N; ++i){
+                        update_index(i);
+                    }
                 }
             }
 
-            // Energía y commit en paralelo
-            #pragma omp for reduction(+:E_global) nowait
-            for (int i=0;i<N;++i){
-                double a = nodes[i].get();
-                E_global += a*a;
+            if (params_.energyAccum == EnergyAccum::Reduction){
+                #pragma omp for reduction(+:E_global)
+                for (int i=0; i<N; ++i){
+                    double a = nodes[i].get();
+                    E_global += a*a;
+                }
+            } else if (params_.energyAccum == EnergyAccum::Atomic){
+                #pragma omp for
+                for (int i=0; i<N; ++i){
+                    double e = nodes[i].get();
+                    e *= e;
+                    #pragma omp atomic
+                    E_global += e;
+                }
+            } else {
+                double local_sum = 0.0;
+                #pragma omp for
+                for (int i=0; i<N; ++i){
+                    double a = nodes[i].get();
+                    local_sum += a*a;
+                }
+                #pragma omp critical
+                {
+                    E_global += local_sum;
+                }
             }
-            #pragma omp for nowait
-            for (int i=0;i<N;++i) nodes[i].commit();
 
-            #pragma omp barrier
+            #pragma omp for
+            for (int i=0; i<N; ++i){
+                nodes[i].commit();
+            }
 
             #pragma omp single
-            { trace.emplace_back(it+1, E_global); local_t += dt; }
+            {
+                if (energy_file){
+                    dump_energy(energy_file, it+1, E_global);
+                }
+                if (params_.dump_frames && params_.frame_every>0 && (it % params_.frame_every == 0)){
+                    if (net_.is2D()) dump_frame_2d(it);
+                    else dump_frame_1d(it);
+                }
+                local_t += dt;
+            }
         }
     }
 
-    // Dump energía (fuera del paralelo)
-    if (!energy_out.empty()){
-        std::filesystem::create_directories("results");
-        std::ofstream f(energy_out);
-        if (f){
-            f << "# step E\n";
-            for (auto &kv : trace) f << kv.first << " " << kv.second << "\n";
-        }
-    }
     tcur_ = local_t;
+    if (energy_file){
+        energy_file.flush();
+    }
 }

--- a/wave_propagation/WavePropagator.h
+++ b/wave_propagation/WavePropagator.h
@@ -1,18 +1,34 @@
 #pragma once
+
+#include <fstream>
+#include <random>
 #include <string>
+#include <vector>
+
 #include "Types.h"
 #include "Network.h"
 
 class WavePropagator {
-    Network* net_;
-    double dt_, S0_, omega_;
-    double tcur_ = 0.0;
 public:
-    WavePropagator(Network* n, double dt, double S0, double omega)
-        : net_(n), dt_(dt), S0_(S0), omega_(omega) {}
+    WavePropagator(Network& net, const RunParams& params);
 
-    void run_fused(int steps, ScheduleType st, int chunk, const std::string& energy_out);
+    void run(const std::string& energy_out);
 
-    // Access
     double time() const { return tcur_; }
+
+private:
+    Network& net_;
+    RunParams params_;
+    double tcur_ = 0.0;
+
+    std::vector<double> omega_i_;
+    int single_idx_ = -1;
+
+    std::mt19937_64 rng_;
+    std::normal_distribution<double> norm_;
+
+    double source_val(int idx, double time) const;
+    void dump_energy(std::ofstream& fe, int step, double E);
+    void dump_frame_1d(int step);
+    void dump_frame_2d(int step);
 };

--- a/wave_propagation/main.cpp
+++ b/wave_propagation/main.cpp
@@ -1,8 +1,10 @@
-#include <iostream>
-#include <string>
-#include <vector>
+#include <algorithm>
 #include <cstdlib>
 #include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 #include <omp.h>
 
 #include "Types.h"
@@ -10,74 +12,92 @@
 #include "WavePropagator.h"
 #include "Benchmark.h"
 
-struct Args {
-    std::string network = "2d"; // {1d,2d}
-    int N = 10000;              // 1d
-    int Lx = 100, Ly = 100;     // 2d
-    double D = 0.1, gamma = 0.01, dt = 0.01;
-    int steps = 200;
-    double S0 = 0.0, omega = 0.0;
-
-    std::string schedule = "dynamic"; // {static,dynamic,guided}
-    int chunk = 32;
-    bool chunk_auto = false;
-
-    std::string threads_csv = "";   // para ejecución simple
-    bool do_bench = false;
-
-    // Mínimo: solo fused (menos barreras)
-    bool fused = true;
-};
-
 static void usage(){
     std::cout << "Uso: ./wave_propagation [opciones]\n"
               << "  --network {1d,2d}\n"
-              << "  --N 10000 | --Lx 100 --Ly 100\n"
-              << "  --D 0.1 --gamma 0.01 --dt 0.01 --steps 200\n"
-              << "  --S0 0.1 --omega 0.5\n"
-              << "  --schedule {static,dynamic,guided}\n"
-              << "  --chunk <n|auto>\n"
-              << "  --threads <n>\n"
+              << "  --N <int> | --Lx <int> --Ly <int>\n"
+              << "  --D <double> --gamma <double> --dt <double>\n"
+              << "  --steps <int>\n"
+              << "  --S0 <double> --omega <double>\n"
+              << "  --noise {off,global,pernode,single}\n"
+              << "  --omega-mu <double> --omega-sigma <double> --noise-node <int>\n"
+              << "  --schedule {static,dynamic,guided} --chunk <n|auto>\n"
+              << "  --threads <int>\n"
+              << "  --taskloop --grain <int>\n"
+              << "  --energy-accum {reduction,atomic,critical}\n"
+              << "  --collapse2\n"
+              << "  --dump-frames --frame-every <int>\n"
               << "  --benchmark\n";
 }
 
 static ScheduleType parse_schedule(const std::string& s){
     if (s=="static") return ScheduleType::Static;
     if (s=="dynamic") return ScheduleType::Dynamic;
-    return ScheduleType::Guided;
+    if (s=="guided")  return ScheduleType::Guided;
+    throw std::runtime_error("schedule invalido");
 }
 
-static int parse_int(const char* s){ return std::atoi(s); }
-static double parse_double(const char* s){ return std::atof(s); }
+static NoiseMode parse_noise(const std::string& s){
+    if (s=="off") return NoiseMode::Off;
+    if (s=="global") return NoiseMode::Global;
+    if (s=="pernode") return NoiseMode::PerNode;
+    if (s=="single") return NoiseMode::Single;
+    throw std::runtime_error("noise invalido");
+}
 
-static Args parse_args(int argc, char** argv){
-    Args a;
+static EnergyAccum parse_energy_accum(const std::string& s){
+    if (s=="reduction") return EnergyAccum::Reduction;
+    if (s=="atomic") return EnergyAccum::Atomic;
+    if (s=="critical") return EnergyAccum::Critical;
+    throw std::runtime_error("energy-accum invalido");
+}
+
+static RunParams parse_args(int argc, char** argv){
+    RunParams params;
     for (int i=1;i<argc;++i){
         std::string k = argv[i];
-        auto need = [&](int idx){ if (idx+1>=argc) { usage(); std::exit(1);} };
-        if (k=="--network"){ need(i); a.network=argv[++i]; }
-        else if (k=="--N"){ need(i); a.N=parse_int(argv[++i]); }
-        else if (k=="--Lx"){ need(i); a.Lx=parse_int(argv[++i]); }
-        else if (k=="--Ly"){ need(i); a.Ly=parse_int(argv[++i]); }
-        else if (k=="--D"){ need(i); a.D=parse_double(argv[++i]); }
-        else if (k=="--gamma"){ need(i); a.gamma=parse_double(argv[++i]); }
-        else if (k=="--dt"){ need(i); a.dt=parse_double(argv[++i]); }
-        else if (k=="--steps"){ need(i); a.steps=parse_int(argv[++i]); }
-        else if (k=="--S0"){ need(i); a.S0=parse_double(argv[++i]); }
-        else if (k=="--omega"){ need(i); a.omega=parse_double(argv[++i]); }
-        else if (k=="--schedule"){ need(i); a.schedule=argv[++i]; }
+        auto next = [&](const char* err){
+            if (i+1>=argc){
+                usage();
+                throw std::runtime_error(err);
+            }
+            return std::string(argv[++i]);
+        };
+        if (k=="--network") params.network = next("--network <1d|2d>");
+        else if (k=="--N") params.N = std::stoi(next("--N <int>"));
+        else if (k=="--Lx") params.Lx = std::stoi(next("--Lx <int>"));
+        else if (k=="--Ly") params.Ly = std::stoi(next("--Ly <int>"));
+        else if (k=="--D") params.D = std::stod(next("--D <double>"));
+        else if (k=="--gamma") params.gamma = std::stod(next("--gamma <double>"));
+        else if (k=="--dt") params.dt = std::stod(next("--dt <double>"));
+        else if (k=="--steps") params.steps = std::stoi(next("--steps <int>"));
+        else if (k=="--S0") params.S0 = std::stod(next("--S0 <double>"));
+        else if (k=="--omega") params.omega = std::stod(next("--omega <double>"));
+        else if (k=="--noise") params.noise = parse_noise(next("--noise <off|global|pernode|single>"));
+        else if (k=="--omega-mu") params.omega_mu = std::stod(next("--omega-mu <double>"));
+        else if (k=="--omega-sigma") params.omega_sigma = std::stod(next("--omega-sigma <double>"));
+        else if (k=="--noise-node") params.noise_node = std::stoi(next("--noise-node <int>"));
+        else if (k=="--schedule") params.schedule = parse_schedule(next("--schedule <static|dynamic|guided>"));
         else if (k=="--chunk"){
-            need(i);
-            std::string v = argv[++i];
-            if (v=="auto") a.chunk_auto = true;
-            else a.chunk = std::atoi(v.c_str());
+            std::string v = next("--chunk <n|auto>");
+            if (v=="auto") params.chunk_auto = true;
+            else params.chunk = std::stoi(v);
         }
-        else if (k=="--threads"){ need(i); a.threads_csv=argv[++i]; }
-        else if (k=="--benchmark"){ a.do_bench = true; }
+        else if (k=="--threads") params.threads = std::stoi(next("--threads <int>"));
+        else if (k=="--taskloop") params.taskloop = true;
+        else if (k=="--grain") params.grain = std::stoi(next("--grain <int>"));
+        else if (k=="--energy-accum") params.energyAccum = parse_energy_accum(next("--energy-accum <reduction|atomic|critical>"));
+        else if (k=="--collapse2") params.collapse2 = true;
+        else if (k=="--dump-frames") params.dump_frames = true;
+        else if (k=="--frame-every") params.frame_every = std::stoi(next("--frame-every <int>"));
+        else if (k=="--benchmark") params.do_bench = true;
         else if (k=="--help" || k=="-h"){ usage(); std::exit(0); }
-        else { std::cerr << "Opcion desconocida: " << k << "\n"; usage(); std::exit(1); }
+        else {
+            usage();
+            throw std::runtime_error("Opcion desconocida: " + k);
+        }
     }
-    return a;
+    return params;
 }
 
 static int compute_auto_chunk(int N, ScheduleType st, int p){
@@ -89,49 +109,51 @@ static int compute_auto_chunk(int N, ScheduleType st, int p){
     return std::min(std::max(c,64),8192);
 }
 
-
 int main(int argc, char** argv){
-    std::filesystem::create_directories("results");
-    Args args = parse_args(argc, argv);
+    try {
+        RunParams params = parse_args(argc, argv);
 
-    ScheduleType st = parse_schedule(args.schedule);
+        std::filesystem::create_directories("results");
+        if (params.dump_frames){
+            std::filesystem::create_directories("results/frames");
+        }
 
-    // Construcción de red (solo 1D/2D)
-    Network net = (args.network=="1d")
-        ? Network(args.N, args.D, args.gamma)
-        : Network(args.Lx, args.Ly, args.D, args.gamma);
-    if (args.network=="1d") net.makeRegular1D(false);
-    else                    net.makeRegular2D(false);
+        // Construcción de red (solo 1D/2D)
+        Network net = (params.network=="1d")
+            ? Network(params.N, params.D, params.gamma)
+            : Network(params.Lx, params.Ly, params.D, params.gamma);
+        if (params.network=="1d") net.makeRegular1D(false);
+        else                       net.makeRegular2D(false);
 
-    // Estado inicial
-    net.setAll(0.0);
-    net.setInitialImpulseCenter(1.0);
+        // Estado inicial
+        net.setAll(0.0);
+        net.setInitialImpulseCenter(1.0);
 
-    if (!args.threads_csv.empty()) {
-        int t = std::atoi(args.threads_csv.c_str());
-        if (t>0) omp_set_num_threads(t);
+        if (params.threads>0) omp_set_num_threads(params.threads);
+
+        if (params.chunk_auto){
+            int p = (params.threads>0) ? params.threads : omp_get_max_threads();
+            params.chunk = compute_auto_chunk(net.size(), params.schedule, p);
+            std::cout << "[auto-chunk] " << params.chunk << "\n";
+        }
+
+        if (params.do_bench){
+            std::vector<int> plist = {1,2,4,8};
+            Benchmark::run_scaling(net, params.steps, params.schedule, params.chunk,
+                                   plist, /*reps*/10, "results/scaling.dat");
+            Benchmark::run_time_vs_chunk_dynamic(net, params.steps, /*threads*/8, /*reps*/10,
+                                                 std::vector<int>{64,128,256,512},
+                                                 "results/time_vs_chunk_dynamic.dat");
+            std::cout << "Benchmarks listos. Revisa carpeta results/\n";
+            return 0;
+        }
+
+        WavePropagator wp(net, params);
+        wp.run(params.energy_out);
+        std::cout << "OK. Resultados en results/\n";
+    } catch (const std::exception& e){
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
     }
-
-    // Heurística de chunk auto
-    if (args.chunk_auto) {
-        int p = omp_get_max_threads();
-        args.chunk = compute_auto_chunk(net.size(), st, p);
-        std::cout << "[auto-chunk] " << args.chunk << "\n";
-    }
-
-    if (args.do_bench){
-        // Scaling y tiempo vs chunk (dynamic)
-        std::vector<int> plist = {1,2,4,8};
-        Benchmark::run_scaling(net, args.steps, st, args.chunk, plist, /*reps*/10, "results/scaling.dat");
-        Benchmark::run_time_vs_chunk_dynamic(net, args.steps, /*threads*/8, /*reps*/10,
-                                             std::vector<int>{64,128,256,512}, "results/time_vs_chunk_dynamic.dat");
-        std::cout << "Benchmarks listos. Revisa carpeta results/\n";
-        return 0;
-    }
-
-    // Ejecucion normal
-    WavePropagator wp(&net, args.dt, args.S0, args.omega);
-    wp.run_fused(args.steps, st, args.chunk, "results/energy_trace.dat");
-    std::cout << "OK. Resultados en results/\n";
     return 0;
 }

--- a/wave_propagation/scripts/make_video.py
+++ b/wave_propagation/scripts/make_video.py
@@ -1,0 +1,57 @@
+import glob
+import os
+import sys
+
+import imageio.v2 as imageio
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def load_frame(fp):
+    if fp.endswith(".csv"):
+        return np.loadtxt(fp, delimiter=",")
+    data = np.loadtxt(fp)
+    return data.reshape(-1, 1)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: python3 scripts/make_video.py <carpeta_frames> <salida.gif>")
+        sys.exit(1)
+    folder = sys.argv[1]
+    out_path = sys.argv[2]
+    pattern_csv = os.path.join(folder, "amp_t*.csv")
+    pattern_dat = os.path.join(folder, "amp_t*.dat")
+    files = sorted(glob.glob(pattern_csv) + glob.glob(pattern_dat))
+    if not files:
+        print("No se encontraron frames en", folder)
+        sys.exit(1)
+
+    vmin = None
+    vmax = None
+    frames = []
+    for fp in files:
+        arr = load_frame(fp)
+        current_min = arr.min()
+        current_max = arr.max()
+        vmin = current_min if vmin is None else min(vmin, current_min)
+        vmax = current_max if vmax is None else max(vmax, current_max)
+        frames.append(arr)
+
+    images = []
+    for arr in frames:
+        fig = plt.figure(figsize=(5, 5))
+        plt.axis("off")
+        plt.imshow(arr, animated=True, vmin=vmin, vmax=vmax, cmap="viridis")
+        fig.canvas.draw()
+        image = np.frombuffer(fig.canvas.tostring_rgb(), dtype="uint8")
+        image = image.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+        images.append(image)
+        plt.close(fig)
+
+    imageio.mimsave(out_path, images, duration=0.06)
+    print(f"GIF guardado en {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a shared RunParams configuration with new noise, energy, taskloop, and output options and extend the CLI to parse the extra flags
- rework the wave propagator to honor the new options (noise modes, energy accumulation strategies, collapse(2), taskloop, frame dumps) and update the benchmark helpers accordingly
- add an analysis Makefile target plus a frame-to-GIF helper script for post-processing

## Testing
- make
- ./wave_propagation --steps 5 --threads 2
- ./wave_propagation --network 2d --Lx 16 --Ly 16 --steps 2 --noise pernode --dump-frames --frame-every 1


------
https://chatgpt.com/codex/tasks/task_e_68dbd635b83c832c9897314caa1ed61e