### PR TITLE
Refine visualization targets and tooling

### DIFF
--- a/wave_propagation/Makefile
+++ b/wave_propagation/Makefile
@@ -6,25 +6,51 @@ TARGET = wave_propagation
 SOURCES = main.cpp Node.cpp Network.cpp WavePropagator.cpp Benchmark.cpp
 HEADERS = Types.h Node.h Network.h WavePropagator.h Benchmark.h
 
+PY ?= python3
+FPS ?= 20
+VIDEO_FORMAT ?= mp4
+FRAMES_DIR := results/frames
+VIDEOS_DIR := videos
+
 $(TARGET): $(SOURCES) $(HEADERS)
 	$(CXX) $(CXXFLAGS) -o $(TARGET) $(SOURCES) $(LDFLAGS)
 
 clean:
 	rm -f $(TARGET) *.o
-	rm -rf results
+	rm -rf results $(VIDEOS_DIR)
 
-.PHONY: clean benchmark analysis
+.PHONY: clean benchmark analysis frames_clean videos_dir video1d video2d video_all
 
 benchmark: $(TARGET)
 	@mkdir -p results
 	./$(TARGET) --benchmark
 
 analysis: $(TARGET)
-	@mkdir -p results results/frames
-	@echo "[analysis] corriendo escalamiento..."
-	@./$(TARGET) --network 2d --Lx 256 --Ly 256 --steps 800 --schedule dynamic --chunk auto \
-	        --threads 8 --energy-accum reduction --noise pernode --S0 0.05 \
-	        --omega-mu 8.0 --omega-sigma 1.5 --collapse2 --dump-frames --frame-every 20
-	@python3 scripts/plot_speedup.py
-	@python3 scripts/plot_chunk.py
-	@python3 scripts/make_video.py results/frames out.gif
+	@mkdir -p results
+	@$(PY) scripts/plot_speedup.py
+	@$(PY) scripts/plot_time_vs_chunk.py
+
+frames_clean:
+	@rm -rf $(FRAMES_DIR) && mkdir -p $(FRAMES_DIR)
+
+videos_dir:
+	@mkdir -p $(VIDEOS_DIR)
+
+# 1D
+video1d: $(TARGET) videos_dir frames_clean
+	@./$(TARGET) --network 1d --N 256 --steps 200 --threads 8 \
+	  --schedule dynamic --chunk auto --noise global --S0 0.2 --omega 6.0 \
+	  --dump-frames --frame-every 1
+	@$(PY) scripts/make_video.py "$(FRAMES_DIR)" --outdir "$(VIDEOS_DIR)" \
+	  --fps $(FPS) --format $(VIDEO_FORMAT)
+
+# 2D
+video2d: $(TARGET) videos_dir frames_clean
+	@./$(TARGET) --network 2d --Lx 64 --Ly 64 --steps 200 --threads 8 \
+	  --schedule dynamic --chunk auto --noise single --S0 0.3 \
+	  --omega-mu 8.0 --omega-sigma 1.0 \
+	  --dump-frames --frame-every 2
+	@$(PY) scripts/make_video.py "$(FRAMES_DIR)" --outdir "$(VIDEOS_DIR)" \
+	  --fps $(FPS) --format $(VIDEO_FORMAT)
+
+video_all: video1d video2d

--- a/wave_propagation/README.md
+++ b/wave_propagation/README.md
@@ -24,11 +24,13 @@ Salida: `results/energy_trace.dat`
 make benchmark
 python3 scripts/plot_speedup.py
 python3 scripts/plot_chunk.py
+python3 scripts/plot_amdahl.py
 ```
 Genera:
 - `results/scaling.dat` → `speedup.png` y `efficiency.png`
   - Formato: `threads mean_time std_time speedup speedup_err efficiency efficiency_err`
 - `results/time_vs_chunk_dynamic.dat` → `time_vs_chunk_dynamic.png`
+- `results/amdahl.png` → comparación `S_p` medido vs. predicción de Amdahl (las desviaciones provienen de caché, NUMA y ruido del sistema).
 
 ## Parámetros recomendados
 - `--schedule dynamic` con `--chunk auto` (heurística elige 256 para dynamic).

--- a/wave_propagation/Types.h
+++ b/wave_propagation/Types.h
@@ -49,4 +49,5 @@ struct RunParams {
     int frame_every = 10;
     bool do_bench = false;
     std::string energy_out = "results/energy_trace.dat";
+    bool use_nowait = false;
 };

--- a/wave_propagation/WavePropagator.h
+++ b/wave_propagation/WavePropagator.h
@@ -20,6 +20,7 @@ private:
     Network& net_;
     RunParams params_;
     double tcur_ = 0.0;
+    double last_1d_sample_ = 0.0;
 
     std::vector<double> omega_i_;
     int single_idx_ = -1;

--- a/wave_propagation/main.cpp
+++ b/wave_propagation/main.cpp
@@ -25,6 +25,7 @@ static void usage(){
               << "  --threads <int>\n"
               << "  --taskloop --grain <int>\n"
               << "  --energy-accum {reduction,atomic,critical}\n"
+              << "  --use-nowait\n"
               << "  --collapse2\n"
               << "  --dump-frames --frame-every <int>\n"
               << "  --benchmark\n";
@@ -87,6 +88,7 @@ static RunParams parse_args(int argc, char** argv){
         else if (k=="--taskloop") params.taskloop = true;
         else if (k=="--grain") params.grain = std::stoi(next("--grain <int>"));
         else if (k=="--energy-accum") params.energyAccum = parse_energy_accum(next("--energy-accum <reduction|atomic|critical>"));
+        else if (k=="--use-nowait") params.use_nowait = true;
         else if (k=="--collapse2") params.collapse2 = true;
         else if (k=="--dump-frames") params.dump_frames = true;
         else if (k=="--frame-every") params.frame_every = std::stoi(next("--frame-every <int>"));

--- a/wave_propagation/scripts/make_video.py
+++ b/wave_propagation/scripts/make_video.py
@@ -1,35 +1,61 @@
+from __future__ import annotations
+
+import argparse
 import glob
-import os
-import sys
+from pathlib import Path
 
 import imageio.v2 as imageio
 import matplotlib.pyplot as plt
 import numpy as np
 
 
-def load_frame(fp):
+def load_frame(fp: str) -> np.ndarray:
     if fp.endswith(".csv"):
         return np.loadtxt(fp, delimiter=",")
     data = np.loadtxt(fp)
     return data.reshape(-1, 1)
 
 
-def main():
-    if len(sys.argv) < 3:
-        print("Uso: python3 scripts/make_video.py <carpeta_frames> <salida.gif>")
-        sys.exit(1)
-    folder = sys.argv[1]
-    out_path = sys.argv[2]
-    pattern_csv = os.path.join(folder, "amp_t*.csv")
-    pattern_dat = os.path.join(folder, "amp_t*.dat")
-    files = sorted(glob.glob(pattern_csv) + glob.glob(pattern_dat))
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Genera un video a partir de los frames volcados por wave_propagation"
+    )
+    parser.add_argument("frames_dir", help="Directorio que contiene archivos amp_t*.dat/csv")
+    parser.add_argument(
+        "--outdir",
+        default="videos",
+        help="Directorio de salida donde se guardará el video (por defecto: %(default)s)",
+    )
+    parser.add_argument(
+        "--fps",
+        type=float,
+        default=20,
+        help="Cuadros por segundo del video generado (por defecto: %(default)s)",
+    )
+    parser.add_argument(
+        "--format",
+        default="mp4",
+        choices=["mp4", "gif"],
+        help="Formato del video de salida (por defecto: %(default)s)",
+    )
+    parser.add_argument(
+        "--basename",
+        default=None,
+        help="Nombre base para el archivo de video sin extensión (por defecto se infiere)",
+    )
+    return parser
+
+
+def collect_frames(frames_dir: Path) -> tuple[list[np.ndarray], np.ndarray]:
+    pattern_csv = frames_dir / "amp_t*.csv"
+    pattern_dat = frames_dir / "amp_t*.dat"
+    files = sorted(glob.glob(str(pattern_csv)) + glob.glob(str(pattern_dat)))
     if not files:
-        print("No se encontraron frames en", folder)
-        sys.exit(1)
+        raise FileNotFoundError(f"No se encontraron frames en {frames_dir}")
 
     vmin = None
     vmax = None
-    frames = []
+    frames: list[np.ndarray] = []
     for fp in files:
         arr = load_frame(fp)
         current_min = arr.min()
@@ -38,7 +64,7 @@ def main():
         vmax = current_max if vmax is None else max(vmax, current_max)
         frames.append(arr)
 
-    images = []
+    images: list[np.ndarray] = []
     for arr in frames:
         fig = plt.figure(figsize=(5, 5))
         plt.axis("off")
@@ -48,9 +74,62 @@ def main():
         image = image.reshape(fig.canvas.get_width_height()[::-1] + (3,))
         images.append(image)
         plt.close(fig)
+    return images, frames[0]
 
-    imageio.mimsave(out_path, images, duration=0.06)
-    print(f"GIF guardado en {out_path}")
+
+def infer_suffix(sample: np.ndarray) -> str:
+    if sample.ndim == 2 and sample.shape[1] == 1:
+        return "1d"
+    if sample.ndim == 2:
+        return "2d"
+    return "data"
+
+
+def ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def save_video(images: list[np.ndarray], out_path: Path, fps: float) -> Path:
+    ensure_directory(out_path.parent)
+    if out_path.suffix.lower() == ".gif":
+        duration = 1.0 / fps if fps > 0 else 0.05
+        imageio.mimsave(out_path, images, duration=duration)
+        return out_path
+
+    try:
+        with imageio.get_writer(out_path, fps=max(fps, 1)) as writer:
+            for frame in images:
+                writer.append_data(frame)
+        return out_path
+    except Exception as exc:  # pragma: no cover - dependencia externa
+        fallback = out_path.with_suffix(".gif")
+        duration = 1.0 / fps if fps > 0 else 0.05
+        imageio.mimsave(fallback, images, duration=duration)
+        print(
+            f"No se pudo escribir {out_path.name} ({exc}). "
+            f"Se generó {fallback.name} como alternativa."
+        )
+        return fallback
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    frames_dir = Path(args.frames_dir)
+    if not frames_dir.exists():
+        raise SystemExit(f"La carpeta {frames_dir} no existe")
+
+    try:
+        images, sample = collect_frames(frames_dir)
+    except FileNotFoundError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    suffix = infer_suffix(sample)
+    base_name = args.basename or f"{frames_dir.name or 'frames'}_{suffix}"
+    out_path = Path(args.outdir) / f"{base_name}.{args.format}"
+    written = save_video(images, out_path, args.fps)
+    print(f"Video guardado en {written}")
 
 
 if __name__ == "__main__":

--- a/wave_propagation/scripts/plot_amdahl.py
+++ b/wave_propagation/scripts/plot_amdahl.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Plot measured speedup against Amdahl's law prediction."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+from typing import Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def estimate_serial_fraction(threads: np.ndarray, speedup: np.ndarray) -> float:
+    """Estimate serial fraction f from measured speedups via least squares."""
+    mask = threads > 1
+    if not np.any(mask):
+        raise ValueError("need at least one measurement with p > 1 to estimate f")
+    numerator = 1.0 / speedup[mask] - 1.0 / threads[mask]
+    denominator = 1.0 - 1.0 / threads[mask]
+    f_vals = numerator / denominator
+    f = float(np.clip(np.mean(f_vals), 0.0, 1.0))
+    return f
+
+
+def load_scaling(path: pathlib.Path) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    data = np.loadtxt(path, comments="#")
+    if data.ndim == 1:
+        data = np.expand_dims(data, axis=0)
+    threads = data[:, 0]
+    speedup = data[:, 3]
+    speedup_err = data[:, 4] if data.shape[1] > 4 else np.zeros_like(speedup)
+    return threads, speedup, speedup_err
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plot Amdahl's law prediction.")
+    parser.add_argument(
+        "--input",
+        default="results/scaling.dat",
+        help="Input scaling data (columns: threads, time, speedup, ...)",
+    )
+    parser.add_argument(
+        "--output",
+        default="results/amdahl.png",
+        help="Path to store the generated figure.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    input_path = pathlib.Path(args.input)
+    if not input_path.exists():
+        raise SystemExit(f"input file '{input_path}' not found")
+
+    threads, speedup, speedup_err = load_scaling(input_path)
+    f = estimate_serial_fraction(threads, speedup)
+    predicted = 1.0 / (f + (1.0 - f) / threads)
+
+    output_path = pathlib.Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    plt.figure(figsize=(6, 4))
+    plt.errorbar(
+        threads,
+        speedup,
+        yerr=speedup_err,
+        fmt="o",
+        capsize=4,
+        label="Medido",
+    )
+    plt.plot(threads, predicted, "-", label=f"Amdahl (f={f:.3f})")
+    plt.xlabel("Hilos (p)")
+    plt.ylabel("Speedup")
+    plt.title("Speedup vs. predicción de Amdahl")
+    plt.grid(True, linestyle="--", alpha=0.5)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output_path)
+    print(f"Amdahl f ≈ {f:.4f} → figura: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wave_propagation/scripts/plot_time_vs_chunk.py
+++ b/wave_propagation/scripts/plot_time_vs_chunk.py
@@ -1,0 +1,7 @@
+"""Compatibilidad: alias de plot_chunk.main para generar la figura tiempo vs. chunk."""
+
+from plot_chunk import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update the Makefile workflow targets with parameterised analysis and video recipes
- add a plot_time_vs_chunk wrapper to keep compatibility with the refreshed analysis target
- extend make_video.py with an argparse CLI, automatic naming, and mp4/gif output support

## Testing
- make -C wave_propagation

------
https://chatgpt.com/codex/tasks/task_e_68dc22d540bc832c92d665dde268e301