### PR TITLE
Update Makefile video targets and add chunk plot wrapper

### DIFF
--- a/wave_propagation/Makefile
+++ b/wave_propagation/Makefile
@@ -20,24 +20,17 @@ benchmark: $(TARGET)
 	./$(TARGET) --benchmark
 
 analysis: $(TARGET)
-	@mkdir -p results results/frames
-	@echo "[analysis] corriendo escalamiento..."
-	@./$(TARGET) --network 2d --Lx 256 --Ly 256 --steps 800 --schedule dynamic --chunk auto \
-	        --threads 8 --energy-accum reduction --noise pernode --S0 0.05 \
-	        --omega-mu 8.0 --omega-sigma 1.5 --collapse2 --dump-frames --frame-every 20
-	@python3 scripts/plot_speedup.py || true
-	@python3 scripts/plot_chunk.py || true
-	@mkdir -p videos
-	@python3 scripts/make_video.py results/frames --mode 2d --outdir videos \
-		--fps 12 --norm robust --robust-pct 1 --interp bilinear --colorbar
+	@mkdir -p results
+	@$(PY) scripts/plot_speedup.py
+	@$(PY) scripts/plot_time_vs_chunk.py
 
 # =====================[ Video helpers ]=====================
 # Puedes sobreescribir estas variables al invocar make:
 PY            ?= python3
-FPS           ?= 12
-VIDEO_FORMAT  ?= gif            # gif | mp4
-FRAMES_DIR    ?= results/frames
-VIDEOS_DIR    ?= videos
+FPS           ?= 20
+VIDEO_FORMAT  ?= mp4
+FRAMES_DIR    := results/frames
+VIDEOS_DIR    := videos
 
 # Presets de visualización (puedes overridearlos desde CLI)
 VIDEO1D_FLAGS ?= --mode 1d --downsample 1500 --zoom1d 250 --mark-peak --zero-center-1d
@@ -46,33 +39,27 @@ VIDEO2D_FLAGS ?= --mode 2d --norm robust --robust-pct 1 --interp bilinear --colo
 .PHONY: video1d video2d video_all frames_clean videos_dir
 
 frames_clean:
-	@rm -rf "$(FRAMES_DIR)"
-	@mkdir -p "$(FRAMES_DIR)"
+	@rm -rf $(FRAMES_DIR) && mkdir -p $(FRAMES_DIR)
 
 videos_dir:
-	@mkdir -p "$(VIDEOS_DIR)"
+	@mkdir -p $(VIDEOS_DIR)
 
 # --------------------- 1D: línea amplitud vs nodo -----------------------
 video1d: $(TARGET) videos_dir frames_clean
-	@echo "[video1d] ejecutando simulacion 1D y volcando frames..."
-	@./$(TARGET) --network 1d --Lx 100 --Ly 1 --steps 50 \
-	  --threads 8 --schedule dynamic --chunk auto \
-	  --noise off --S0 0.0 --omega 0.0 \
-	  --dump-frames --frame-every 1
-	@echo "[video1d] creando video..."
+	@./$(TARGET) --network 1d --N 256 --steps 200 --threads 8 \
+	--schedule dynamic --chunk auto --noise global --S0 0.2 --omega 6.0 \
+	--dump-frames --frame-every 1
 	@$(PY) scripts/make_video.py "$(FRAMES_DIR)" --outdir "$(VIDEOS_DIR)" \
-	  --fps $(FPS) --format $(VIDEO_FORMAT) $(VIDEO1D_FLAGS)
+	--fps $(FPS) --format $(VIDEO_FORMAT) $(VIDEO1D_FLAGS)
 
 # ----------------------- 2D: mapa de calor ------------------------------
 video2d: $(TARGET) videos_dir frames_clean
-	@echo "[video2d] ejecutando simulacion 2D y volcando frames..."
-	@./$(TARGET) --network 2d --Lx 64 --Ly 64 --steps 50 \
-	  --threads 8 --schedule dynamic --chunk auto \
-	  --noise single --S0 0.3 --omega-mu 8.0 --omega-sigma 1.0 \
-	  --dump-frames --frame-every 1
-	@echo "[video2d] creando video..."
+	@./$(TARGET) --network 2d --Lx 64 --Ly 64 --steps 200 --threads 8 \
+	--schedule dynamic --chunk auto --noise single --S0 0.3 \
+	--omega-mu 8.0 --omega-sigma 1.0 \
+	--dump-frames --frame-every 2
 	@$(PY) scripts/make_video.py "$(FRAMES_DIR)" --outdir "$(VIDEOS_DIR)" \
-	  --fps $(FPS) --format $(VIDEO_FORMAT) $(VIDEO2D_FLAGS)
+	--fps $(FPS) --format $(VIDEO_FORMAT) $(VIDEO2D_FLAGS)
 
 video_all: video1d video2d
 # ===========================================================

--- a/wave_propagation/scripts/plot_time_vs_chunk.py
+++ b/wave_propagation/scripts/plot_time_vs_chunk.py
@@ -1,0 +1,5 @@
+from plot_chunk import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- align the benchmark and analysis rules with the refreshed helper scripts
- streamline the video generation targets with explicit frame cleanup and export options
- add a plot_time_vs_chunk helper that reuses the existing chunk plotting script

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc315a6658832c9805fb6617af2636