### PR TITLE
Add Amdahl plot target and video generation docs

### DIFF
--- a/wave_propagation/Makefile
+++ b/wave_propagation/Makefile
@@ -13,16 +13,20 @@ clean:
 	rm -f $(TARGET) *.o
 	rm -rf results videos
 
-.PHONY: clean benchmark analysis
+.PHONY: clean benchmark analysis amdahl
 
 benchmark: $(TARGET)
 	@mkdir -p results
 	./$(TARGET) --benchmark
 
 analysis: $(TARGET)
-	@mkdir -p results
-	@$(PY) scripts/plot_speedup.py
-	@$(PY) scripts/plot_time_vs_chunk.py
+        @mkdir -p results
+        @$(PY) scripts/plot_speedup.py
+        @$(PY) scripts/plot_time_vs_chunk.py
+        @$(PY) scripts/plot_amdahl.py
+
+amdahl: $(TARGET)
+        @$(PY) scripts/plot_amdahl.py --input results/scaling.dat --output results/amdahl.png
 
 # =====================[ Video helpers ]=====================
 # Puedes sobreescribir estas variables al invocar make:

--- a/wave_propagation/README.md
+++ b/wave_propagation/README.md
@@ -32,6 +32,12 @@ Genera:
 - `results/time_vs_chunk_dynamic.dat` → `time_vs_chunk_dynamic.png`
 - `results/amdahl.png` → comparación `S_p` medido vs. predicción de Amdahl (las desviaciones provienen de caché, NUMA y ruido del sistema).
 
+## Cómo generar video
+- **1D:** `make video1d`
+- **2D:** `make video2d`
+
+Tips: puedes aumentar `--frame-every` si quieres que avance más lento y ajustar la resolución para mantener buena calidad (requisito del curso).
+
 ## Parámetros recomendados
 - `--schedule dynamic` con `--chunk auto` (heurística elige 256 para dynamic).
 - Si la carga es homogénea, `static` también sirve; `guided` es intermedio.


### PR DESCRIPTION
## Summary
- add a dedicated `amdahl` make target and integrate the plot into the `analysis` recipe
- document how to generate the 1D/2D videos and provide tips about frame cadence and resolution

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc3719ce34832c95fbbf953fa373d0